### PR TITLE
Correção da página inicial

### DIFF
--- a/src/pages/Root/Root.jsx
+++ b/src/pages/Root/Root.jsx
@@ -13,16 +13,12 @@ export function Root() {
   useEffect(() => {
     if(usuarioLogado === null){
       navigator("/loading");
-    }else{
-      navigator("/");
     }
   }, [])
 
   setTimeout(() => {
     if(usuarioLogado === null){
       navigator("/login");
-    }else{
-      navigator("/");
     }
   }, 1500);
 


### PR DESCRIPTION
A página inicial não estava exibindo as páginas de livros e empréstimos, voltando sempre para a home. Erro corrigido.